### PR TITLE
Feat/mf 114(판매자 프로필 및 판매자의 모든 자료)

### DIFF
--- a/src/main/java/majorfolio/backend/root/config/WebSecurityConfig.java
+++ b/src/main/java/majorfolio/backend/root/config/WebSecurityConfig.java
@@ -50,7 +50,7 @@ public class WebSecurityConfig {
                         "/health-check",
                         "/v3/api-docs/**",
                         "/home/banner",
-                        "home/all/univ/**")
+                        "home/all/**")
                 .requestMatchers("/*"); // 인증 처리 하지 않을 케이스
     }
 }

--- a/src/main/java/majorfolio/backend/root/config/WebSecurityConfig.java
+++ b/src/main/java/majorfolio/backend/root/config/WebSecurityConfig.java
@@ -50,7 +50,8 @@ public class WebSecurityConfig {
                         "/health-check",
                         "/v3/api-docs/**",
                         "/home/banner",
-                        "home/all/**")
+                        "/home/all/**",
+                        "/seller/**")
                 .requestMatchers("/*"); // 인증 처리 하지 않을 케이스
     }
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/api/HomeController.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/api/HomeController.java
@@ -3,6 +3,7 @@ package majorfolio.backend.root.domain.material.api;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import majorfolio.backend.root.domain.material.dto.response.MaterialListResponse;
+import majorfolio.backend.root.domain.material.dto.response.NameMaterialListResponse;
 import majorfolio.backend.root.domain.material.dto.response.SingleMaterialListResponse;
 import majorfolio.backend.root.domain.material.service.MaterialAllListService;
 import majorfolio.backend.root.domain.material.service.MaterialService;
@@ -40,6 +41,13 @@ public class HomeController {
     public SingleMaterialListResponse getAllUnivLike(@RequestParam(name = "page") int page,
                                                             @RequestParam(name = "pageSize", defaultValue = "10") int pageSize){
         return materialAllListService.getAllUnivLike(page, pageSize);
+    }
+
+    @GetMapping("all/subject")
+    public NameMaterialListResponse getAllSubjectNewly(@RequestParam(name = "materialID") Long materialID,
+            @RequestParam(name = "page") int page,
+            @RequestParam(name = "pageSize", defaultValue = "10") int pageSize){
+        return materialAllListService.getAllSubjectNew(page, pageSize, materialID);
     }
 
 

--- a/src/main/java/majorfolio/backend/root/domain/material/api/SellerController.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/api/SellerController.java
@@ -1,0 +1,33 @@
+package majorfolio.backend.root.domain.material.api;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import majorfolio.backend.root.domain.material.dto.response.NameMaterialListResponse;
+import majorfolio.backend.root.domain.material.dto.response.SellerMaterialListResponse;
+import majorfolio.backend.root.domain.material.dto.response.SellerProfileResponse;
+import majorfolio.backend.root.domain.material.service.MaterialAllListService;
+import majorfolio.backend.root.domain.material.service.ProfileService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/seller")
+@RequiredArgsConstructor
+public class SellerController {
+    private final MaterialAllListService materialAllListService;
+    private final ProfileService profileService;
+
+    @GetMapping("/assignment")
+    public SellerMaterialListResponse getAllSellerList(@RequestParam(name = "nickName") String nickName,
+                                                       @RequestParam(name = "page") int page,
+                                                       @RequestParam(name = "pageSize", defaultValue = "10") int pageSize){
+        return materialAllListService.getSellerList(page, pageSize, nickName);
+    }
+
+    @GetMapping("/profile")
+    public SellerProfileResponse getSellerProfile(@RequestParam(name = "nickName") String nickName){
+        return profileService.getSellerProfile(nickName);
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/MaterialResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/MaterialResponse.java
@@ -14,9 +14,11 @@ import majorfolio.backend.root.domain.material.entity.Material;
 public class MaterialResponse {
     private final Long id;
     private final String nickname;
-    private final String subjectName;
+    private final String className;
     private final String univ;
     private final String major;
+    private final String semester;
+    private final String professor;
     private final int like;
 
     /**
@@ -28,9 +30,11 @@ public class MaterialResponse {
         return MaterialResponse.builder()
                 .id(material.getId())
                 .nickname(material.getMember().getNickName())
-                .subjectName(material.getName())
+                .className(material.getClassName())
                 .univ(material.getMember().getUniversityName())
                 .major(material.getMajor())
+                .semester(material.getSemester())
+                .professor(material.getProfessor())
                 .like(material.getTotalRecommend())
                 .build();
     }

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/NameMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/NameMaterialListResponse.java
@@ -1,0 +1,30 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * material들의 list 응답 형태 정의
+ * @author 김태혁
+ * @version 0.0.1
+ */
+@Getter
+@Builder
+public class NameMaterialListResponse {
+    private int page;
+    private final List<NameMaterialResponse> newUpload;
+
+    /**
+     * material들의 list 응답 형태 생성
+     * @author 김태혁
+     * @version 0.0.1
+     */
+    public static NameMaterialListResponse of(int page, List<NameMaterialResponse> newUpload){
+        return NameMaterialListResponse.builder()
+                .page(page)
+                .newUpload(newUpload)
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/NameMaterialResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/NameMaterialResponse.java
@@ -1,0 +1,41 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import majorfolio.backend.root.domain.material.entity.Material;
+
+/**
+ * material의 응답 형태 정의
+ * @author 김태혁
+ * @version 0.0.1
+ */
+@Getter
+@Builder
+public class NameMaterialResponse {
+    private final Long id;
+    private final String nickname;
+    private final String name;
+    private final String univ;
+    private final String major;
+    private final String semester;
+    private final String professor;
+    private final int like;
+
+    /**
+     * material의 응답 형태 생성
+     * @author 김태혁
+     * @version 0.0.1
+     */
+    public static NameMaterialResponse of(Material material) {
+        return NameMaterialResponse.builder()
+                .id(material.getId())
+                .nickname(material.getMember().getNickName())
+                .name(material.getName())
+                .univ(material.getMember().getUniversityName())
+                .major(material.getMajor())
+                .semester(material.getSemester())
+                .professor(material.getProfessor())
+                .like(material.getTotalRecommend())
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerMaterialListResponse.java
@@ -1,0 +1,30 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * material들의 list 응답 형태 정의
+ * @author 김태혁
+ * @version 0.0.1
+ */
+@Getter
+@Builder
+public class SellerMaterialListResponse {
+    private int page;
+    private final List<SellerMaterialResponse> sellList;
+
+    /**
+     * material들의 list 응답 형태 생성
+     * @author 김태혁
+     * @version 0.0.1
+     */
+    public static SellerMaterialListResponse of(int page, List<SellerMaterialResponse> sellList){
+        return SellerMaterialListResponse.builder()
+                .page(page)
+                .sellList(sellList)
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerMaterialResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerMaterialResponse.java
@@ -1,0 +1,46 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import majorfolio.backend.root.domain.material.entity.Material;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * material의 응답 형태 정의
+ * @author 김태혁
+ * @version 0.0.1
+ */
+@Getter
+@Builder
+public class SellerMaterialResponse {
+    private final Long id;
+    private final String nickname;
+    private final String name;
+    private final String univ;
+    private final String major;
+    private final String semester;
+    private final String professor;
+    private final int like;
+    private final LocalDateTime createdAt;
+
+    /**
+     * material의 응답 형태 생성
+     * @author 김태혁
+     * @version 0.0.1
+     */
+    public static SellerMaterialResponse of(Material material) {
+        return SellerMaterialResponse.builder()
+                .id(material.getId())
+                .nickname(material.getMember().getNickName())
+                .name(material.getName())
+                .univ(material.getMember().getUniversityName())
+                .major(material.getMajor())
+                .semester(material.getSemester())
+                .professor(material.getProfessor())
+                .like(material.getTotalRecommend())
+                .createdAt(material.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerProfileResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerProfileResponse.java
@@ -1,0 +1,29 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import majorfolio.backend.root.domain.member.entity.Member;
+
+@Getter
+@Builder
+public class SellerProfileResponse {
+    private String nickName;
+    private String univName;
+    private String major;
+    private String image_url;
+    private int upload;
+    private int sell;
+    private int follower;
+
+    public static SellerProfileResponse of(Member member, int upload, int sell, int follower){
+        return SellerProfileResponse.builder()
+                .nickName(member.getNickName())
+                .univName(member.getUniversityName())
+                .major(member.getMajor1())
+                .image_url(member.getProfileImage())
+                .upload(upload)
+                .sell(sell)
+                .follower(follower)
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/SingleMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/SingleMaterialListResponse.java
@@ -13,6 +13,7 @@ import java.util.List;
 @Getter
 @Builder
 public class SingleMaterialListResponse {
+    private int page;
     private final List<MaterialResponse> materialResponseList;
 
     /**
@@ -20,8 +21,9 @@ public class SingleMaterialListResponse {
      * @author 김태혁
      * @version 0.0.1
      */
-    public static SingleMaterialListResponse of(List<MaterialResponse> materialResponseList){
+    public static SingleMaterialListResponse of(int page, List<MaterialResponse> materialResponseList){
         return SingleMaterialListResponse.builder()
+                .page(page)
                 .materialResponseList(materialResponseList)
                 .build();
     }

--- a/src/main/java/majorfolio/backend/root/domain/material/repository/MaterialRepository.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/repository/MaterialRepository.java
@@ -1,6 +1,7 @@
 package majorfolio.backend.root.domain.material.repository;
 
 import majorfolio.backend.root.domain.material.entity.Material;
+import majorfolio.backend.root.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -73,5 +74,6 @@ public interface MaterialRepository extends JpaRepository<Material, Long> {
     Page<Material> findByMajorOrderByTotalRecommendDescIdAsc(String universityName, Pageable pageable);
 
     Page<Material> findByClassNameAndProfessorAndMember_UniversityNameAndMajor(String className, String professor, String universityName, String major, Pageable pageable);
+    Page<Material> findByMember(Member member, Pageable pageable);
 
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/repository/MaterialRepository.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/repository/MaterialRepository.java
@@ -71,4 +71,7 @@ public interface MaterialRepository extends JpaRepository<Material, Long> {
     Page<Material> findByMajorOrderByCreatedAtDescIdAsc(String universityName, Pageable pageable);
 
     Page<Material> findByMajorOrderByTotalRecommendDescIdAsc(String universityName, Pageable pageable);
+
+    Page<Material> findByClassNameAndProfessorAndMember_UniversityNameAndMajor(String className, String professor, String universityName, String major, Pageable pageable);
+
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/service/MaterialAllListService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/MaterialAllListService.java
@@ -2,13 +2,12 @@ package majorfolio.backend.root.domain.material.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import majorfolio.backend.root.domain.material.dto.response.MaterialResponse;
-import majorfolio.backend.root.domain.material.dto.response.NameMaterialListResponse;
-import majorfolio.backend.root.domain.material.dto.response.NameMaterialResponse;
-import majorfolio.backend.root.domain.material.dto.response.SingleMaterialListResponse;
+import majorfolio.backend.root.domain.material.dto.response.*;
 import majorfolio.backend.root.domain.material.entity.Material;
 import majorfolio.backend.root.domain.material.repository.MaterialRepository;
+import majorfolio.backend.root.domain.member.entity.Member;
 import majorfolio.backend.root.domain.member.repository.KakaoSocialLoginRepository;
+import majorfolio.backend.root.domain.member.repository.MemberRepository;
 import majorfolio.backend.root.global.exception.NotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,6 +22,7 @@ import java.util.stream.Collectors;
 public class MaterialAllListService {
     private final MaterialRepository materialRepository;
     private final KakaoSocialLoginRepository kakaoSocialLoginRepository;
+    private final MemberRepository memberRepository;
 
 
     public SingleMaterialListResponse getAllUnivUploadList(int page, int pageSize) {
@@ -108,6 +108,15 @@ public class MaterialAllListService {
         return NameMaterialListResponse.of(page, nameMaterialResponses);
     }
 
+    public SellerMaterialListResponse getSellerList(int page, int pageSize, String nickName) {
+        Member member = memberRepository.findByNickName(nickName);
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+        Page<Material> materialPage = materialRepository.findByMember(member, pageable);
+        List<SellerMaterialResponse> nameMaterialResponses = convertToMaterialSellerResponseList(materialPage.getContent());
+
+        return SellerMaterialListResponse.of(page, nameMaterialResponses);
+    }
+
     private List<MaterialResponse> convertToMaterialResponseList(List<Material> materials) {
 
         return materials.stream()
@@ -119,6 +128,13 @@ public class MaterialAllListService {
 
         return materials.stream()
                 .map(NameMaterialResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    private List<SellerMaterialResponse> convertToMaterialSellerResponseList(List<Material> materials) {
+
+        return materials.stream()
+                .map(SellerMaterialResponse::of)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/majorfolio/backend/root/domain/material/service/MaterialAllListService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/MaterialAllListService.java
@@ -3,6 +3,8 @@ package majorfolio.backend.root.domain.material.service;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import majorfolio.backend.root.domain.material.dto.response.MaterialResponse;
+import majorfolio.backend.root.domain.material.dto.response.NameMaterialListResponse;
+import majorfolio.backend.root.domain.material.dto.response.NameMaterialResponse;
 import majorfolio.backend.root.domain.material.dto.response.SingleMaterialListResponse;
 import majorfolio.backend.root.domain.material.entity.Material;
 import majorfolio.backend.root.domain.material.repository.MaterialRepository;
@@ -34,7 +36,7 @@ public class MaterialAllListService {
             throw new NotFoundException("더 이상 자료가 없습니다.");
         }
 
-        return SingleMaterialListResponse.of(materialResponses);
+        return SingleMaterialListResponse.of(page, materialResponses);
     }
 
     public SingleMaterialListResponse getAllUnivLike(int page, int pageSize) {
@@ -43,7 +45,7 @@ public class MaterialAllListService {
 
         List<MaterialResponse> materialResponses = convertToMaterialResponseList(materialPage.getContent());
 
-        return SingleMaterialListResponse.of(materialResponses);
+        return SingleMaterialListResponse.of(page, materialResponses);
     }
 
     public SingleMaterialListResponse getMyUnivUploadList(int page, int pageSize, HttpServletRequest request) {
@@ -55,7 +57,7 @@ public class MaterialAllListService {
 
         List<MaterialResponse> materialResponses = convertToMaterialResponseList(materialPage.getContent());
 
-        return SingleMaterialListResponse.of(materialResponses);
+        return SingleMaterialListResponse.of(page, materialResponses);
     }
 
     public SingleMaterialListResponse getMyUnivLike(int page, int pageSize, HttpServletRequest request) {
@@ -67,7 +69,7 @@ public class MaterialAllListService {
 
         List<MaterialResponse> materialResponses = convertToMaterialResponseList(materialPage.getContent());
 
-        return SingleMaterialListResponse.of(materialResponses);
+        return SingleMaterialListResponse.of(page, materialResponses);
     }
 
     public SingleMaterialListResponse getMyMajorUploadList(int page, int pageSize, HttpServletRequest request) {
@@ -79,7 +81,7 @@ public class MaterialAllListService {
 
         List<MaterialResponse> materialResponses = convertToMaterialResponseList(materialPage.getContent());
 
-        return SingleMaterialListResponse.of(materialResponses);
+        return SingleMaterialListResponse.of(page, materialResponses);
     }
 
     public SingleMaterialListResponse getMyMajorLike(int page, int pageSize, HttpServletRequest request) {
@@ -91,13 +93,32 @@ public class MaterialAllListService {
 
         List<MaterialResponse> materialResponses = convertToMaterialResponseList(materialPage.getContent());
 
-        return SingleMaterialListResponse.of(materialResponses);
+        return SingleMaterialListResponse.of(page, materialResponses);
+    }
+
+    public NameMaterialListResponse getAllSubjectNew(int page, int pageSize, Long materialID) {
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+        Material material = materialRepository.findById(materialID).orElse(null);
+
+        assert material != null;
+        Page<Material> materialPage = materialRepository.findByClassNameAndProfessorAndMember_UniversityNameAndMajor(material.getClassName(), material.getProfessor(), material.getMember().getUniversityName(), material.getMajor(), pageable);
+
+        List<NameMaterialResponse> nameMaterialResponses = convertToMaterialNamedResponseList(materialPage.getContent());
+
+        return NameMaterialListResponse.of(page, nameMaterialResponses);
     }
 
     private List<MaterialResponse> convertToMaterialResponseList(List<Material> materials) {
 
         return materials.stream()
                 .map(MaterialResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    private List<NameMaterialResponse> convertToMaterialNamedResponseList(List<Material> materials) {
+
+        return materials.stream()
+                .map(NameMaterialResponse::of)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/majorfolio/backend/root/domain/material/service/ProfileService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/ProfileService.java
@@ -1,0 +1,18 @@
+package majorfolio.backend.root.domain.material.service;
+
+import lombok.RequiredArgsConstructor;
+import majorfolio.backend.root.domain.material.dto.response.SellerProfileResponse;
+import majorfolio.backend.root.domain.member.entity.Member;
+import majorfolio.backend.root.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+    private final MemberRepository memberRepository;
+    public SellerProfileResponse getSellerProfile(String nickName) {
+        Member member = memberRepository.findByNickName(nickName);
+        //아직 upload, sell, follower에 대한 기능 미구현으로 우선 0으로 대체후 나중에 구현 예정
+        return SellerProfileResponse.of(member, 0, 0, 0);
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/member/repository/MemberRepository.java
+++ b/src/main/java/majorfolio/backend/root/domain/member/repository/MemberRepository.java
@@ -21,4 +21,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsMemberByNickName(String nickname);
+
+    Member findByNickName(String nickName);
 }


### PR DESCRIPTION
판매자의 모든 자료보기에 해당하는 기능 구현 및 프로필 조회 기능 구현
프로필에서 통계에 대한 부분(업로드수, 판매수, 팔로워수)은 아직 미구현 그냥 0으로 해놨음
판매자료는 모두 볼 수 있도록 구현(10개씩 전달)
예외처리는 아직 미구현