### PR TITLE
Feat/mf 213 구매자료보기 구현(주석, 예외처리 X)

### DIFF
--- a/src/main/java/majorfolio/backend/root/config/WebConfig.java
+++ b/src/main/java/majorfolio/backend/root/config/WebConfig.java
@@ -25,7 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/member/login");
         registry.addInterceptor(serviceServerTokenInterceptor)
                 .order(1)
-                .addPathPatterns("/member/**", "/assignment/**", "/my/**", "/home/my/**")
+                .addPathPatterns("/member/**", "/assignment/**", "/my/**", "/home/my/**", "/library/**")
                 .excludePathPatterns("/member/login", "/member/remake/token", "/assignment/{materialId}/detail");
         registry.addInterceptor(refreshTokenInterceptor)
                 .order(1)

--- a/src/main/java/majorfolio/backend/root/domain/material/api/LibraryController.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/api/LibraryController.java
@@ -1,0 +1,23 @@
+package majorfolio.backend.root.domain.material.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import majorfolio.backend.root.domain.material.dto.response.LibraryMaterialListResponse;
+import majorfolio.backend.root.domain.material.service.LibraryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/library")
+@RequiredArgsConstructor
+@Slf4j
+public class LibraryController {
+    private final LibraryService libraryService;
+
+    @GetMapping("/buy")
+    public LibraryMaterialListResponse getBuyMaterialList(HttpServletRequest request){
+        return libraryService.getBuyMaterialList(request);
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/api/LibraryController.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/api/LibraryController.java
@@ -7,8 +7,12 @@ import majorfolio.backend.root.domain.material.dto.response.LibraryMaterialListR
 import majorfolio.backend.root.domain.material.service.LibraryService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 자료함에 대한 Controller
+ */
 @RestController
 @RequestMapping("/library")
 @RequiredArgsConstructor
@@ -16,8 +20,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class LibraryController {
     private final LibraryService libraryService;
 
+    /**
+     * 구매한 자료들을 인피니티 페이지로 전달받는 메서드
+     * @param page
+     * @param pageSize
+     * @param request
+     * @return
+     */
     @GetMapping("/buy")
-    public LibraryMaterialListResponse getBuyMaterialList(HttpServletRequest request){
-        return libraryService.getBuyMaterialList(request);
+    public LibraryMaterialListResponse getBuyMaterialList(@RequestParam(name = "page") int page,
+                                                          @RequestParam(name = "pageSize", defaultValue = "10") int pageSize,
+                                                          HttpServletRequest request){
+        return libraryService.getBuyMaterialList(page, pageSize, request);
     }
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialListResponse.java
@@ -13,7 +13,7 @@ public class LibraryMaterialListResponse {
     private final List<LibraryMaterialResponse> downloadComplete;
 
     /**
-     * material들의 list 응답 형태 생성
+     * 구매한 자료들의 카테고리에 따른 반환
      * @author 김태혁
      * @version 0.0.1
      */

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialListResponse.java
@@ -1,0 +1,29 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class LibraryMaterialListResponse {
+    private final List<LibraryMaterialResponse> beforePay;
+    private final List<LibraryMaterialResponse> afterPay;
+    private final List<LibraryMaterialResponse> downloadComplete;
+
+    /**
+     * material들의 list 응답 형태 생성
+     * @author 김태혁
+     * @version 0.0.1
+     */
+    public static LibraryMaterialListResponse of(List<LibraryMaterialResponse> beforePay,
+                                          List<LibraryMaterialResponse> afterPay,
+                                          List<LibraryMaterialResponse> downloadComplete){
+        return LibraryMaterialListResponse.builder()
+                .beforePay(beforePay)
+                .afterPay(afterPay)
+                .downloadComplete(downloadComplete)
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialResponse.java
@@ -6,6 +6,9 @@ import majorfolio.backend.root.domain.material.entity.Material;
 
 import java.time.LocalDateTime;
 
+/**
+ * 구매한 자료들의 반환 형태
+ */
 @Getter
 @Builder
 public class LibraryMaterialResponse {

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/LibraryMaterialResponse.java
@@ -1,0 +1,41 @@
+package majorfolio.backend.root.domain.material.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import majorfolio.backend.root.domain.material.entity.Material;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class LibraryMaterialResponse {
+    private final Long id;
+    private final Long memberId;
+    private final String imageUrl;
+    private final String nickname;
+    private final String className;
+    private final String univ;
+    private final String major;
+    private final String semester;
+    private final String professor;
+    private final int like;
+    private final LocalDateTime updateDate;
+    private final Long buyInfoId;
+
+    public static LibraryMaterialResponse of(Material material, LocalDateTime updateDate, Long buyInfoId) {
+        return LibraryMaterialResponse.builder()
+                .id(material.getId())
+                .memberId(material.getMember().getId())
+                .imageUrl(material.getMember().getProfileImage())
+                .nickname(material.getMember().getNickName())
+                .className(material.getClassName())
+                .univ(material.getMember().getUniversityName())
+                .major(material.getMajor())
+                .semester(material.getSemester())
+                .professor(material.getProfessor())
+                .like(material.getTotalRecommend())
+                .updateDate(updateDate)
+                .buyInfoId(buyInfoId)
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/repository/MaterialRepository.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/repository/MaterialRepository.java
@@ -126,6 +126,12 @@ public interface MaterialRepository extends JpaRepository<Material, Long> {
      */
     List<Material> findAllByClassNameAndStatus(String className, String status);
 
+    /**
+     * 해당 유저의 과제가 판매중인 리스트를 반환
+     * @param member
+     * @param status
+     * @return
+     */
     List<Material> findAllByMemberAndStatus(Member member, String status);
 
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/service/LibraryService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/LibraryService.java
@@ -1,0 +1,83 @@
+package majorfolio.backend.root.domain.material.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import majorfolio.backend.root.domain.material.dto.response.LibraryMaterialListResponse;
+import majorfolio.backend.root.domain.material.dto.response.LibraryMaterialResponse;
+import majorfolio.backend.root.domain.member.entity.BuyList;
+import majorfolio.backend.root.domain.member.entity.BuyListItem;
+import majorfolio.backend.root.domain.member.entity.KakaoSocialLogin;
+import majorfolio.backend.root.domain.member.repository.BuyListItemRepository;
+import majorfolio.backend.root.domain.member.repository.KakaoSocialLoginRepository;
+import majorfolio.backend.root.global.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LibraryService {
+    private final KakaoSocialLoginRepository kakaoSocialLoginRepository;
+    private final BuyListItemRepository buyListItemRepository;
+
+    public LibraryMaterialListResponse getBuyMaterialList(HttpServletRequest request) {
+        Object kakaoIdAttribute = request.getAttribute("kakaoId");
+
+        if (kakaoIdAttribute == null) {
+            // 카카오 아이디가 없을 때의 예외 처리 또는 메시지 전달 등의 처리
+            throw new NotFoundException("카카오 아이디를 찾을 수 없습니다.");
+        }
+
+        Long kakaoId = Long.parseLong(kakaoIdAttribute.toString());
+
+        // 카카오 아이디에 해당하는 값 조회
+        KakaoSocialLogin kakaoSocialLogin = kakaoSocialLoginRepository.findById(kakaoId).orElse(null);
+        if (kakaoSocialLogin == null || kakaoSocialLogin.getMember() == null || kakaoSocialLogin.getMember().getMajor1() == null) {
+            // 카카오 아이디에 해당하는 값이 없을 때의 예외 처리 또는 메시지 전달 등의 처리
+            throw new NotFoundException("카카오 아이디에 해당하는 정보를 찾을 수 없습니다.");
+        }
+
+        BuyList buyList = kakaoSocialLogin.getMember().getBuyList();
+
+        List<BuyListItem> buyListItems = buyListItemRepository.findAllByBuyListOrderByBuyInfoCreatedAtDesc(buyList);
+
+
+        List<BuyListItem> beforeBuyListItem = new ArrayList<>();
+        List<BuyListItem> afterBuyListItem= new ArrayList<>();
+        List<BuyListItem> downBuyListItem= new ArrayList<>();
+
+        for(BuyListItem buyListItem : buyListItems){
+            if(!buyListItem.getBuyInfo().getIsPay())
+                beforeBuyListItem.add(buyListItem);
+            else{
+                if(!buyListItem.getIsDown())
+                    afterBuyListItem.add(buyListItem);
+                else
+                    downBuyListItem.add(buyListItem);
+            }
+        }
+
+        List<LibraryMaterialResponse> beforeList = convertToLibraryMaterialResponseListByBuyListItem(beforeBuyListItem);
+        List<LibraryMaterialResponse> afterList = convertToLibraryMaterialResponseListByBuyListItem(afterBuyListItem);
+        List<LibraryMaterialResponse> downList = convertToDownLibraryMaterialResponseListByBuyListItem(downBuyListItem);
+
+        return LibraryMaterialListResponse.of(beforeList, afterList, downList);
+    }
+
+    private List<LibraryMaterialResponse> convertToLibraryMaterialResponseListByBuyListItem(List<BuyListItem> buyListItems) {
+        List<LibraryMaterialResponse> lists = new ArrayList<>();
+        for(BuyListItem buyListItem : buyListItems)
+            lists.add(LibraryMaterialResponse.of(buyListItem.getMaterial(), buyListItem.getBuyInfo().getUpdatedAt(),buyListItem.getBuyInfo().getId()));
+        return lists;
+    }
+
+    private List<LibraryMaterialResponse> convertToDownLibraryMaterialResponseListByBuyListItem(List<BuyListItem> buyListItems) {
+        List<LibraryMaterialResponse> lists = new ArrayList<>();
+        for(BuyListItem buyListItem : buyListItems)
+            lists.add(LibraryMaterialResponse.of(buyListItem.getMaterial(), buyListItem.getUpdatedAt(),buyListItem.getBuyInfo().getId()));
+        return lists;
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/service/ProfileService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/ProfileService.java
@@ -32,6 +32,11 @@ public class ProfileService {
     private final FollowerRepository followerRepository;
     private final KakaoSocialLoginRepository kakaoSocialLoginRepository;
 
+    /**
+     * 프로필에 대한 정보를 반환
+     * @param memberId
+     * @return
+     */
     public ProfileResponse getProfile(Long memberId) {
         Member member = memberRepository.findById(memberId).orElse(null);
         if (member == null) {

--- a/src/main/java/majorfolio/backend/root/domain/member/entity/BuyListItem.java
+++ b/src/main/java/majorfolio/backend/root/domain/member/entity/BuyListItem.java
@@ -1,0 +1,47 @@
+package majorfolio.backend.root.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import majorfolio.backend.root.domain.material.entity.Material;
+import majorfolio.backend.root.domain.payments.entity.BuyInfo;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class BuyListItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "buyListItem_id")
+    private Long id;
+
+    private Boolean isDown;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @OneToOne
+    @JoinColumn(name = "material_id")
+    private Material material;
+
+    @ManyToOne
+    @JoinColumn(name = "buyList_id")
+    private BuyList buyList;
+
+    @ManyToOne
+    @JoinColumn(name = "buyInfo_id")
+    private BuyInfo buyInfo;
+
+    public static BuyListItem of(Material material, BuyList buyList){
+        return BuyListItem.builder()
+                .isDown(false)
+                .material(material)
+                .buyList(buyList)
+                .build();
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/member/entity/BuyListItem.java
+++ b/src/main/java/majorfolio/backend/root/domain/member/entity/BuyListItem.java
@@ -8,6 +8,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
+/**
+ * 구매한 아이템들을 정의한 클래스
+ */
 @Builder
 @Entity
 @AllArgsConstructor

--- a/src/main/java/majorfolio/backend/root/domain/member/repository/BuyListItemRepository.java
+++ b/src/main/java/majorfolio/backend/root/domain/member/repository/BuyListItemRepository.java
@@ -1,0 +1,11 @@
+package majorfolio.backend.root.domain.member.repository;
+
+import majorfolio.backend.root.domain.member.entity.BuyList;
+import majorfolio.backend.root.domain.member.entity.BuyListItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BuyListItemRepository extends JpaRepository<BuyListItem, Long> {
+    List<BuyListItem> findAllByBuyListOrderByBuyInfoCreatedAtDesc(BuyList buyList);
+}

--- a/src/main/java/majorfolio/backend/root/domain/member/repository/BuyListItemRepository.java
+++ b/src/main/java/majorfolio/backend/root/domain/member/repository/BuyListItemRepository.java
@@ -2,10 +2,18 @@ package majorfolio.backend.root.domain.member.repository;
 
 import majorfolio.backend.root.domain.member.entity.BuyList;
 import majorfolio.backend.root.domain.member.entity.BuyListItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BuyListItemRepository extends JpaRepository<BuyListItem, Long> {
-    List<BuyListItem> findAllByBuyListOrderByBuyInfoCreatedAtDesc(BuyList buyList);
+    /**
+     * 페이지와 구매리스트 아이디에 맞는 모든 구매자료들을 반환
+     * @param buyList
+     * @param pageable
+     * @return
+     */
+    Page<BuyListItem> findAllByBuyListOrderByBuyInfoCreatedAtDesc(BuyList buyList, Pageable pageable);
 }

--- a/src/main/java/majorfolio/backend/root/domain/payments/entity/BuyInfo.java
+++ b/src/main/java/majorfolio/backend/root/domain/payments/entity/BuyInfo.java
@@ -10,6 +10,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 결제를 통해 생성되는 구매정보에 대한 클래스
+ */
 @Entity
 @Builder
 @NoArgsConstructor

--- a/src/main/java/majorfolio/backend/root/domain/payments/entity/BuyInfo.java
+++ b/src/main/java/majorfolio/backend/root/domain/payments/entity/BuyInfo.java
@@ -1,0 +1,54 @@
+package majorfolio.backend.root.domain.payments.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import majorfolio.backend.root.domain.member.entity.BuyListItem;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class BuyInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "buyInfo_id")
+    private Long id;
+
+    private String code;
+    private int price;
+    private Long buyerId;
+    private Boolean isPay;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+    private String status;
+
+    @Builder.Default
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "buyInfo")
+    private List<BuyListItem> buyListItems = new ArrayList<>();
+
+    public void addBuyListItem(BuyListItem buyListItem)
+    {
+        buyListItems.add(buyListItem);
+        buyListItem.setBuyInfo(this);
+    }
+
+    public static BuyInfo of(String code, int price, Long buyerId, String status){
+        return BuyInfo.builder()
+                .code(code)
+                .price(price)
+                .buyerId(buyerId)
+                .isPay(false)
+                .status(status)
+                .build();
+    }
+}


### PR DESCRIPTION
구매자료 보기 기능 구현 (아직 주석, 예외처리는 X) -> 머지 안할거

"library/buy" get (토큰 필요)
유저가 구매한 자료(구매의 기준은 구매하기 버튼을 통해 송금안내 페이지가 형성된 것들)를
결제 대기 / 결제 완료 / 다운 완료 로 리스트 형태 반환(송금 안내 페이지가 만들어진 날 최신순)
결제 대기 -> BuyInfo의 상태가 beforePay (즉 buyinfo의 isPay가 false)
결제 완료-> BuyInfo의 상태가 afterPay (즉 buyinfo의 isPay가 true) 그에 해당하는 BuyListItem의 isDown이 false
다운 완료-> BuyInfo의 상태가 afterPay (즉 buyinfo의 isPay가 true) 그에 해당하는 BuyListItem의 isDown이 �true
현재는 구매자의 모든 buylist를 반환하는데 이게 나중에 한 유저가 100개의 자료를 구매하면 어떻게 할것인지 상의해봐야 할 듯
-> 이것도 인피니티 스크롤?(스크롤로 하면 카테고리에 따라 페이지를 설정해야하는지 아니면 전체를 페이지로 설정해야 하는지 등)