### PR TITLE
Feat/mf 99 : admin 유저, 과제 신고 정보 조회 및 각 접수에 따라 유저, 과제 ben 처리 기능 추가

### DIFF
--- a/src/main/java/majorfolio/backend/root/domain/admin/api/AdminController.java
+++ b/src/main/java/majorfolio/backend/root/domain/admin/api/AdminController.java
@@ -1,0 +1,37 @@
+package majorfolio.backend.root.domain.admin.api;
+
+import lombok.RequiredArgsConstructor;
+import majorfolio.backend.root.domain.admin.service.AdminService;
+import majorfolio.backend.root.domain.report.entity.MaterialReport;
+import majorfolio.backend.root.domain.report.entity.MemberReport;
+import majorfolio.backend.root.global.response.BaseResponse;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+    private final AdminService adminService;
+
+    @GetMapping("/report/member")
+    public BaseResponse<List<MemberReport>> getMemberReport(){
+        return new BaseResponse<>(adminService.getMemberReport());
+    }
+
+    @GetMapping("/report/material")
+    public BaseResponse<List<MaterialReport>> getMaterialReport(){
+        return new BaseResponse<>(adminService.getMaterialReport());
+    }
+
+    @PatchMapping("/report/member/{reportId}")
+    public BaseResponse<String> changeMemberReport(@PathVariable(name = "reportId") Long reportId){
+        return new BaseResponse<>(adminService.changeMemberReport(reportId));
+    }
+
+    @PatchMapping("/report/material/{reportId}")
+    public BaseResponse<String> changeMaterialReport(@PathVariable(name = "reportId") Long reportId){
+        return new BaseResponse<>(adminService.changeMaterialReport(reportId));
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/admin/service/AdminService.java
+++ b/src/main/java/majorfolio/backend/root/domain/admin/service/AdminService.java
@@ -1,0 +1,69 @@
+package majorfolio.backend.root.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import majorfolio.backend.root.domain.material.entity.Material;
+import majorfolio.backend.root.domain.material.repository.MaterialRepository;
+import majorfolio.backend.root.domain.member.entity.Member;
+import majorfolio.backend.root.domain.member.repository.MemberRepository;
+import majorfolio.backend.root.domain.report.entity.MaterialReport;
+import majorfolio.backend.root.domain.report.entity.MemberReport;
+import majorfolio.backend.root.domain.report.repository.MaterialReportRepository;
+import majorfolio.backend.root.domain.report.repository.MemberReportRepository;
+import majorfolio.backend.root.global.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static majorfolio.backend.root.global.response.status.BaseExceptionStatus.NOT_PRESENT_MATERIAL;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+    private final MemberReportRepository memberReportRepository;
+    private final MaterialReportRepository materialReportRepository;
+    private final MemberRepository memberRepository;
+    private final MaterialRepository materialRepository;
+    public List<MemberReport> getMemberReport() {
+        return memberReportRepository.findAll();
+    }
+
+    public List<MaterialReport> getMaterialReport() {
+        return materialReportRepository.findAll();
+    }
+
+    public String changeMemberReport(Long reportId) {
+        MemberReport memberReport = memberReportRepository.findById(reportId).orElse(null);
+        if(memberReport == null)
+            throw new RuntimeException("없는 유저신고 아이디입니다.");
+
+        Member member = memberRepository.findById(memberReport.getReportedUserId()).orElse(null);
+        if(member==null)
+            throw new RuntimeException("없는 유저입니다");
+        member.setStatus("ben");
+        memberRepository.save(member);
+
+        memberReport.setStatus("complete");
+        memberReport.setProcessing(true);
+        memberReportRepository.save(memberReport);
+
+        return "유저신고가 정상적으로 처리되었습니다.";
+    }
+
+    public String changeMaterialReport(Long reportId) {
+        MaterialReport materialReport = materialReportRepository.findById(reportId).orElse(null);
+        if(materialReport == null)
+            throw new RuntimeException("없는 유저신고 아이디입니다.");
+
+        Material material = materialRepository.findById(materialReport.getReportedMaterialId()).orElse(null);
+        if(material == null)
+            throw new NotFoundException(NOT_PRESENT_MATERIAL);
+
+        material.setStatus("ben");
+        materialRepository.save(material);
+
+        materialReport.setStatus("complete");
+        materialReport.setProcessing(true);
+        materialReportRepository.save(materialReport);
+        return "과제신고가 정상적으로 처리되었습니다";
+    }
+}

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/NameMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/NameMaterialListResponse.java
@@ -15,16 +15,18 @@ import java.util.List;
 public class NameMaterialListResponse {
     private int page;
     private final List<NameMaterialResponse> newUpload;
+    private boolean isEnd;
 
     /**
      * material들의 list 응답 형태 생성
      * @author 김태혁
      * @version 0.0.1
      */
-    public static NameMaterialListResponse of(int page, List<NameMaterialResponse> newUpload){
+    public static NameMaterialListResponse of(int page, List<NameMaterialResponse> newUpload, boolean isEnd){
         return NameMaterialListResponse.builder()
                 .page(page)
                 .newUpload(newUpload)
+                .isEnd(isEnd)
                 .build();
     }
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/SellerMaterialListResponse.java
@@ -15,16 +15,18 @@ import java.util.List;
 public class SellerMaterialListResponse {
     private int page;
     private final List<SellerMaterialResponse> sellList;
+    private boolean isEnd;
 
     /**
      * material들의 list 응답 형태 생성
      * @author 김태혁
      * @version 0.0.1
      */
-    public static SellerMaterialListResponse of(int page, List<SellerMaterialResponse> sellList){
+    public static SellerMaterialListResponse of(int page, List<SellerMaterialResponse> sellList, boolean isEnd){
         return SellerMaterialListResponse.builder()
                 .page(page)
                 .sellList(sellList)
+                .isEnd(isEnd)
                 .build();
     }
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/SingleMaterialListResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/SingleMaterialListResponse.java
@@ -15,16 +15,18 @@ import java.util.List;
 public class SingleMaterialListResponse {
     private int page;
     private final List<MaterialResponse> materialResponseList;
+    private boolean isEnd;
 
     /**
      * material들의 list 응답 형태 생성
      * @author 김태혁
      * @version 0.0.1
      */
-    public static SingleMaterialListResponse of(int page, List<MaterialResponse> materialResponseList){
+    public static SingleMaterialListResponse of(int page, List<MaterialResponse> materialResponseList, boolean isEnd){
         return SingleMaterialListResponse.builder()
                 .page(page)
                 .materialResponseList(materialResponseList)
+                .isEnd(isEnd)
                 .build();
     }
 }

--- a/src/main/java/majorfolio/backend/root/domain/material/service/MaterialAllListService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/MaterialAllListService.java
@@ -49,7 +49,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SingleMaterialListResponse.of(page, materialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SingleMaterialListResponse.of(page, materialResponses, isLastPage);
     }
 
     /**
@@ -67,7 +70,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SingleMaterialListResponse.of(page, materialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SingleMaterialListResponse.of(page, materialResponses, isLastPage);
     }
 
     /**
@@ -103,7 +109,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SingleMaterialListResponse.of(page, materialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SingleMaterialListResponse.of(page, materialResponses, isLastPage);
     }
 
     /**
@@ -140,7 +149,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SingleMaterialListResponse.of(page, materialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SingleMaterialListResponse.of(page, materialResponses, isLastPage);
     }
 
     /**
@@ -176,7 +188,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SingleMaterialListResponse.of(page, materialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SingleMaterialListResponse.of(page, materialResponses, isLastPage);
     }
 
     /**
@@ -211,7 +226,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SingleMaterialListResponse.of(page, materialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SingleMaterialListResponse.of(page, materialResponses, isLastPage);
     }
 
     /**
@@ -232,7 +250,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return NameMaterialListResponse.of(page, nameMaterialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return NameMaterialListResponse.of(page, nameMaterialResponses, isLastPage);
     }
 
     /**
@@ -256,7 +277,10 @@ public class MaterialAllListService {
             throw new NotFoundException(NOT_FOUND_MATERIAL);
         }
 
-        return SellerMaterialListResponse.of(page, nameMaterialResponses);
+        int totalPages = materialPage.getTotalPages();
+        boolean isLastPage = page >= totalPages;
+
+        return SellerMaterialListResponse.of(page, nameMaterialResponses, isLastPage);
     }
 
     /**

--- a/src/main/java/majorfolio/backend/root/domain/report/entity/MaterialReport.java
+++ b/src/main/java/majorfolio/backend/root/domain/report/entity/MaterialReport.java
@@ -1,10 +1,7 @@
 package majorfolio.backend.root.domain.report.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@Getter @Setter
 public class MaterialReport {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +35,7 @@ public class MaterialReport {
                 .reason(reason)
                 .description(description)
                 .processing(false)
-                .status("received")
+                .status("accepted")
                 .build();
     }
 

--- a/src/main/java/majorfolio/backend/root/domain/report/entity/MemberReport.java
+++ b/src/main/java/majorfolio/backend/root/domain/report/entity/MemberReport.java
@@ -1,10 +1,7 @@
 package majorfolio.backend.root.domain.report.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@Getter @Setter
 public class MemberReport {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,7 +35,7 @@ public class MemberReport {
                 .reason(reason)
                 .description(description)
                 .processing(false)
-                .status("received")
+                .status("accepted")
                 .build();
     }
 

--- a/src/main/java/majorfolio/backend/root/global/status/StatusEnum.java
+++ b/src/main/java/majorfolio/backend/root/global/status/StatusEnum.java
@@ -17,7 +17,8 @@ public enum StatusEnum implements DBstatus{
     //Material테이블 쪽 status
     MATERIAL_ACTIVE("Material", "active", "활성상태"),
     MATERIAL_REVIEWING("Material", "reviewing", "대기상태"),
-    MATERIAL_OLD("Material", "old", "수정전 파일");
+    MATERIAL_OLD("Material", "old", "수정전 파일"),
+    MATERIAL_BEN("Material", "ben", "신고당한 파일");
 
 
     private final String DBTable;


### PR DESCRIPTION
우선은 그냥 admin에 의한 요청은 토큰이나 이런거 확인 안하게 해놨어!! 이거는 뭐 나중에 해서 해도 될듯? 기능만 돌아가도록 했으
GET admin/member -> 유저 신고 모든 정보 전달
GET admin/material -> 과제 신고 모든 정보 전달
PATCH admin/member/{reportId} -> 해당하는 유저신고 벤처리
PATCH admin/material/{reportId} -> 해당하는 과제신고 벤처리