### PR TITLE
QA : 마이페이지, 판매자 페이지 2전공 전달 추가 + 마이페이지 내 정보 수정 기능 추가

### DIFF
--- a/src/main/java/majorfolio/backend/root/domain/material/api/MyController.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/api/MyController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import majorfolio.backend.root.domain.material.dto.response.*;
 import majorfolio.backend.root.domain.material.service.MyService;
 import majorfolio.backend.root.domain.material.service.ProfileService;
+import majorfolio.backend.root.domain.member.dto.request.MyInfoRequest;
 import majorfolio.backend.root.domain.member.dto.request.ProfileImageRequest;
 import majorfolio.backend.root.global.response.BaseResponse;
 import org.springframework.web.bind.annotation.*;
@@ -140,5 +141,10 @@ public class MyController {
     @GetMapping("/event/{eventId}")
     public BaseResponse<ShowEventDetailResponse> showEventDetail(@PathVariable(name = "eventId") Long eventId) throws InvalidKeySpecException, IOException {
         return new BaseResponse<>(myService.showEventDetail(eventId));
+    }
+
+    @PatchMapping("/change")
+    public BaseResponse<String> changeMyInfo(@RequestBody MyInfoRequest myInfoRequest, HttpServletRequest request){
+        return new BaseResponse<>(myService.changeMyInfo(myInfoRequest,request));
     }
  }

--- a/src/main/java/majorfolio/backend/root/domain/material/dto/response/ProfileResponse.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/dto/response/ProfileResponse.java
@@ -15,6 +15,7 @@ public class ProfileResponse {
     private String nickName;
     private String univ;
     private String major;
+    private String major2;
     private String image_url;
     private Long upload;
     private Long sell;
@@ -25,6 +26,7 @@ public class ProfileResponse {
                 .nickName(member.getNickName())
                 .univ(member.getUniversityName())
                 .major(member.getMajor1())
+                .major2(member.getMajor2())
                 .image_url(member.getProfileImage())
                 .upload(upload)
                 .sell(sell)

--- a/src/main/java/majorfolio/backend/root/domain/material/service/MyService.java
+++ b/src/main/java/majorfolio/backend/root/domain/material/service/MyService.java
@@ -19,6 +19,7 @@ import majorfolio.backend.root.domain.admin.repository.NoticeRepository;
 import majorfolio.backend.root.domain.material.dto.response.*;
 import majorfolio.backend.root.domain.material.entity.Material;
 import majorfolio.backend.root.domain.material.repository.MaterialRepository;
+import majorfolio.backend.root.domain.member.dto.request.MyInfoRequest;
 import majorfolio.backend.root.domain.member.dto.request.ProfileImageRequest;
 import majorfolio.backend.root.domain.member.entity.Bookmark;
 import majorfolio.backend.root.domain.member.entity.KakaoSocialLogin;
@@ -339,5 +340,28 @@ public class MyService {
         Event event = eventRepository.findById(eventId).get();
         String link = S3Util.makeSignedUrl(event.getLink(), s3Bucket, 0L, 0L, EVENTS3.getS3DirectoryName(), privateKeyFilePath, distributionDomain, keyPairId, amazonS3);
         return ShowEventDetailResponse.of(event.getTitle(), link);
+    }
+
+    public String changeMyInfo(MyInfoRequest myInfoRequest, HttpServletRequest request) {
+        Member member = memberGlobalService.getMemberByToken(request).getMember();
+
+        if (myInfoRequest.getNickName() != null) {
+            member.setNickName(myInfoRequest.getNickName());
+        }
+        if (myInfoRequest.getMajor1() != null) {
+            member.setMajor1(myInfoRequest.getMajor1());
+        }
+        if (myInfoRequest.getMajor2() != null) {
+            member.setMajor2(myInfoRequest.getMajor2());
+        }
+        if (myInfoRequest.getStudentId() != 0) { // Check for non-zero studentId
+            member.setStudentId(myInfoRequest.getStudentId());
+        }
+        if (myInfoRequest.getPhoneNumber() != null) {
+            member.setPhoneNumber(myInfoRequest.getPhoneNumber());
+        }
+
+        memberRepository.save(member);
+        return "정상적으로 유저의 정보가 변경되었습니다.";
     }
 }

--- a/src/main/java/majorfolio/backend/root/domain/member/dto/request/MyInfoRequest.java
+++ b/src/main/java/majorfolio/backend/root/domain/member/dto/request/MyInfoRequest.java
@@ -1,0 +1,18 @@
+package majorfolio.backend.root.domain.member.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class MyInfoRequest {
+    private String nickName;
+    private String major1;
+    private String major2;
+    private int studentId;
+    @Pattern(regexp="\\d{3}-\\d{4}-\\d{4}", message="phoneNumber : 올바른 전화번호 형식이 아닙니다.")
+    private String phoneNumber;
+}


### PR DESCRIPTION
프로필에서 제2전공도 추강
patch my/change를 통해 닉네임, 전공1, 전공2, 학번, 전화번호에 대한 업데이트 기능 추가